### PR TITLE
Add extra check for win32 to fix deadlock

### DIFF
--- a/gtk/gtk.init.lisp
+++ b/gtk/gtk.init.lisp
@@ -61,14 +61,16 @@
                                 ;; version gtk-main which puts the C function
                                 ;; %gtk-main between gdk-thread-enter und
                                 ;; gdk-thread-leave
-                                (unless (find :win32 *features*)
+                                (unless (or (find :os-windows *features*)
+                                            (find :win32 *features*))
                                   (gdk-threads-init)   ;; Calling on win32 will deadlock
                                   (gdk-threads-enter)) ;; Calling on win32 will deadlock
                                 (unwind-protect
                                     (progn
 ;                                      (%gtk-init)
                                       (%gtk-main))
-                                  (unless (find :win32 *features*)
+                                  (unless (or (find :os-windows *features*)
+                                              (find :win32 *features*))
                                     (gdk-threads-leave)) ;; Calling on win32 will deadlock
                                   ))
                               :name "cl-cffi-gtk main thread")


### PR DESCRIPTION
Current check for Windows is insufficient on Clozure CL. Fixes #23.