### PR TITLE
implemented binding for gdk-drag-context-get-suggested-action

### DIFF
--- a/gdk/gdk.drag-and-drop.lisp
+++ b/gdk/gdk.drag-and-drop.lisp
@@ -511,6 +511,10 @@
 ;;;
 ;;; Since 2.22
 ;;; ----------------------------------------------------------------------------
+(defcfun ("gdk_drag_context_get_suggested_action" gdk-drag-context-get-suggested-action)
+    gdk-drag-action 
+  (context (g-object gdk-drag-context)))
+(export 'gdk-drag-context-get-suggested-action)
 
 ;;; ----------------------------------------------------------------------------
 ;;; gdk_drag_context_get_selected_action ()


### PR DESCRIPTION
gdk-drag-context-get-suggested-action is necessary for custom "drag-motion" handlers

I will probably need to add a few more missing bindings soon. Please advise on the best way to comment (I was wary of inserting docstrings - they look generated...

Should the context parameter  (context (g-object gdk-drag-context))) be marked as :already-referenced? I do not have a good grasp of the gdk reference counting interplay with cl-cffi-gtk.

Thanks
