### PR TITLE
Remove `cairo-destroy` from draw handler

### DIFF
--- a/tutorial/src/gtk-tutorial.lisp
+++ b/tutorial/src/gtk-tutorial.lisp
@@ -317,7 +317,6 @@ sem venenatis, vitae ultricies arcu laoreet."))
              (let ((cr (pointer cr)))
                (cairo-set-source-surface cr surface 0.0 0.0)
                (cairo-paint cr)
-               (cairo-destroy cr)
                +gdk-event-propagate+)))
         (g-signal-connect area "configure-event"
            (lambda (widget event)


### PR DESCRIPTION
`(cairo-destroy cr)` in `example-drawing` actually crashes the application